### PR TITLE
chore(package.json): update repository url for moved package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kareem
 
   [![Build Status](https://github.com/mongoosejs/kareem/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/mongoosejs/kareem/actions/workflows/test.yml)
-  [![Coverage Status](https://img.shields.io/coveralls/vkarpov15/kareem.svg)](https://coveralls.io/r/vkarpov15/kareem)
+  <!--[![Coverage Status](https://img.shields.io/coveralls/vkarpov15/kareem.svg)](https://coveralls.io/r/vkarpov15/kareem)-->
 
 Re-imagined take on the [hooks](http://npmjs.org/package/hooks) module, meant to offer additional flexibility in allowing you to execute hooks whenever necessary, as opposed to simply wrapping a single function.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kareem
 
-  [![Build Status](https://travis-ci.org/vkarpov15/kareem.svg?branch=master)](https://travis-ci.org/vkarpov15/kareem)
+  [![Build Status](https://github.com/mongoosejs/kareem/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/mongoosejs/kareem/actions/workflows/test.yml)
   [![Coverage Status](https://img.shields.io/coveralls/vkarpov15/kareem.svg)](https://coveralls.io/r/vkarpov15/kareem)
 
 Re-imagined take on the [hooks](http://npmjs.org/package/hooks) module, meant to offer additional flexibility in allowing you to execute hooks whenever necessary, as opposed to simply wrapping a single function.
@@ -417,4 +417,3 @@ assert.equal(k3._pres.get('cook')[0].fn, test2);
 assert.equal(k3._pres.get('cook')[1].fn, test1);
 assert.equal(k3._posts.get('cook').length, 1);
 ```
-

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/vkarpov15/kareem.git"
+    "url": "git://github.com/mongoosejs/kareem.git"
   },
   "devDependencies": {
     "acquit": "1.x",


### PR DESCRIPTION
This PR does:
- update package.json `repository` field for the moved repo
- update README to use github-ci badges instead of travis
- update README to remove coverage status (because it is currently not submitted since 2.3.0 anyway)