### PR TITLE
Update workflow versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [12, 14, 16, 18]
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [18]
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
     name: Lint
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16, 18]
+        node: [12, 14, 16, 18, 20, 22]
         os: [ubuntu-24.04]
     name: Node ${{ matrix.node }}
     steps:
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18]
+        node: [22]
         os: [ubuntu-24.04]
     name: Lint
     steps:


### PR DESCRIPTION
This PR updates the workflow's `ubuntu` and nodejs versions as `ubuntu-20.04` has been retired in github actions this month (https://github.com/actions/runner-images/issues/11101). Additionally updates to include newer nodejs versions in the tests.

PS: DRAFT until proven the CI works successfully.