### PR TITLE
Update README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ object, rather than relying on inheritance. Furthermore, kareem exposes
 an `execPre()` function that allows you to execute your pre hooks when
 appropriate, giving you more fine-grained control over your function hooks.
 
-#### It runs without any hooks specified
+### It runs without any hooks specified
 
 ```javascript
 hooks.execPre('cook', null, function() {
@@ -30,7 +30,7 @@ hooks.execPre('cook', null, function() {
 });
 ```
 
-#### It runs basic serial pre hooks
+### It runs basic serial pre hooks
 
 pre hook functions take one parameter, a "done" function that you execute
 when your pre hook is finished.
@@ -48,7 +48,7 @@ hooks.execPre('cook', null, function() {
 });
 ```
 
-#### It can run multipe pre hooks
+### It can run multipe pre hooks
 
 ```javascript
 let count1 = 0;
@@ -70,7 +70,7 @@ hooks.execPre('cook', null, function() {
 });
 ```
 
-#### It can run fully synchronous pre hooks
+### It can run fully synchronous pre hooks
 
 If your pre hook function takes no parameters, its assumed to be
 fully synchronous.
@@ -94,7 +94,7 @@ hooks.execPre('cook', null, function(error) {
 });
 ```
 
-#### It properly attaches context to pre hooks
+### It properly attaches context to pre hooks
 
 Pre save hook functions are bound to the second parameter to `execPre()`
 
@@ -119,7 +119,7 @@ hooks.execPre('cook', obj, function(error) {
 });
 ```
 
-#### It can execute parallel (async) pre hooks
+### It can execute parallel (async) pre hooks
 
 Like the hooks module, you can declare "async" pre hooks - these take two
 parameters, the functions `next()` and `done()`. `next()` passes control to
@@ -158,7 +158,7 @@ hooks.execPre('cook', obj, function() {
 });
 ```
 
-#### It supports returning a promise
+### It supports returning a promise
 
 You can also return a promise from your pre hooks instead of calling
 `next()`. When the returned promise resolves, kareem will kick off the
@@ -185,7 +185,7 @@ hooks.execPre('cook', obj, function() {
 
 acquit:ignore:end
 
-#### It runs without any hooks specified
+### It runs without any hooks specified
 
 ```javascript
 hooks.execPost('cook', null, [1], function(error, eggs) {
@@ -195,7 +195,7 @@ hooks.execPost('cook', null, [1], function(error, eggs) {
 });
 ```
 
-#### It executes with parameters passed in
+### It executes with parameters passed in
 
 ```javascript
 hooks.post('cook', function(eggs, bacon, callback) {
@@ -211,7 +211,7 @@ hooks.execPost('cook', null, [1, 2], function(error, eggs, bacon) {
 });
 ```
 
-#### It can use synchronous post hooks
+### It can use synchronous post hooks
 
 ```javascript
 const execed = {};
@@ -239,7 +239,7 @@ hooks.execPost('cook', null, [1, 2], function(error, eggs, bacon) {
 });
 ```
 
-#### It supports returning a promise
+### It supports returning a promise
 
 You can also return a promise from your post hooks instead of calling
 `next()`. When the returned promise resolves, kareem will kick off the
@@ -266,7 +266,7 @@ hooks.execPost('cook', obj, obj, function() {
 
 acquit:ignore:end
 
-#### It wraps pre and post calls into one call
+### It wraps pre and post calls into one call
 
 ```javascript
 hooks.pre('cook', true, function(next, done) {
@@ -324,7 +324,7 @@ hooks.wrap(
 
 ## createWrapper()
 
-#### It wraps wrap() into a callable function
+### It wraps wrap() into a callable function
 
 ```javascript
 hooks.pre('cook', true, function(next, done) {
@@ -381,7 +381,7 @@ cook(obj, function(error, result) {
 
 acquit:ignore:end
 
-#### It clones a Kareem object
+### It clones a Kareem object
 
 ```javascript
 const k1 = new Kareem();
@@ -395,7 +395,7 @@ assert.deepEqual(Array.from(k2._posts.keys()), ['cook']);
 
 ## merge()
 
-#### It pulls hooks from another Kareem object
+### It pulls hooks from another Kareem object
 
 ```javascript
 const k1 = new Kareem();

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Named for the NBA's all-time leading scorer Kareem Abdul-Jabbar, known for his m
 
 <img src="http://upload.wikimedia.org/wikipedia/commons/0/00/Kareem-Abdul-Jabbar_Lipofsky.jpg" width="220">
 
+<!--DOCS START-->
+
 # API
 
 ## pre hooks
@@ -36,7 +38,7 @@ when your pre hook is finished.
 
 
 ```javascript
-var count = 0;
+let count = 0;
 
 hooks.pre('cook', function(done) {
   ++count;
@@ -51,8 +53,8 @@ hooks.execPre('cook', null, function() {
 #### It can run multipe pre hooks
 
 ```javascript
-var count1 = 0;
-var count2 = 0;
+let count1 = 0;
+let count2 = 0;
 
 hooks.pre('cook', function(done) {
   ++count1;
@@ -77,8 +79,8 @@ fully synchronous.
 
 
 ```javascript
-var count1 = 0;
-var count2 = 0;
+let count1 = 0;
+let count2 = 0;
 
 hooks.pre('cook', function() {
   ++count1;
@@ -111,7 +113,7 @@ hooks.pre('cook', function(done) {
   done();
 });
 
-var obj = { bacon: 0, eggs: 0 };
+const obj = { bacon: 0, eggs: 0 };
 
 // In the pre hooks, `this` will refer to `obj`
 hooks.execPre('cook', obj, function(error) {
@@ -140,7 +142,7 @@ hooks.pre('cook', true, function(next, done) {
 
 hooks.pre('cook', true, function(next, done) {
   next();
-  var _this = this;
+  const _this = this;
   setTimeout(function() {
     _this.eggs = 4;
     done();
@@ -152,7 +154,7 @@ hooks.pre('cook', function(next) {
   next();
 });
 
-var obj = { bacon: 0, eggs: 0 };
+const obj = { bacon: 0, eggs: 0 };
 
 hooks.execPre('cook', obj, function() {
   assert.equal(3, obj.bacon);
@@ -178,7 +180,7 @@ hooks.pre('cook', function() {
   });
 });
 
-var obj = { bacon: 0 };
+const obj = { bacon: 0 };
 
 hooks.execPre('cook', obj, function() {
   assert.equal(3, obj.bacon);
@@ -218,7 +220,7 @@ hooks.execPost('cook', null, [1, 2], function(error, eggs, bacon) {
 #### It can use synchronous post hooks
 
 ```javascript
-var execed = {};
+const execed = {};
 
 hooks.post('cook', function(eggs, bacon) {
   execed.first = true;
@@ -251,7 +253,7 @@ next middleware.
 
 
 ```javascript
-hooks.post('cook', function(bacon) {
+hooks.post('cook', function() {
   return new Promise(resolve => {
     setTimeout(() => {
       this.bacon = 3;
@@ -260,7 +262,7 @@ hooks.post('cook', function(bacon) {
   });
 });
 
-var obj = { bacon: 0 };
+const obj = { bacon: 0 };
 
 hooks.execPost('cook', obj, obj, function() {
   assert.equal(obj.bacon, 3);
@@ -284,7 +286,7 @@ hooks.pre('cook', true, function(next, done) {
 
 hooks.pre('cook', true, function(next, done) {
   next();
-  var _this = this;
+  const _this = this;
   setTimeout(function() {
     _this.eggs = 4;
     done();
@@ -300,9 +302,9 @@ hooks.post('cook', function(obj) {
   obj.tofu = 'no';
 });
 
-var obj = { bacon: 0, eggs: 0 };
+const obj = { bacon: 0, eggs: 0 };
 
-var args = [obj];
+const args = [obj];
 args.push(function(error, result) {
   assert.ifError(error);
   assert.equal(null, error);
@@ -342,7 +344,7 @@ hooks.pre('cook', true, function(next, done) {
 
 hooks.pre('cook', true, function(next, done) {
   next();
-  var _this = this;
+  const _this = this;
   setTimeout(function() {
     _this.eggs = 4;
     done();
@@ -358,9 +360,9 @@ hooks.post('cook', function(obj) {
   obj.tofu = 'no';
 });
 
-var obj = { bacon: 0, eggs: 0 };
+const obj = { bacon: 0, eggs: 0 };
 
-var cook = hooks.createWrapper(
+const cook = hooks.createWrapper(
   'cook',
   function(o, callback) {
     assert.equal(3, obj.bacon);
@@ -389,11 +391,11 @@ acquit:ignore:end
 #### It clones a Kareem object
 
 ```javascript
-var k1 = new Kareem();
+const k1 = new Kareem();
 k1.pre('cook', function() {});
 k1.post('cook', function() {});
 
-var k2 = k1.clone();
+const k2 = k1.clone();
 assert.deepEqual(Array.from(k2._pres.keys()), ['cook']);
 assert.deepEqual(Array.from(k2._posts.keys()), ['cook']);
 ```
@@ -403,17 +405,18 @@ assert.deepEqual(Array.from(k2._posts.keys()), ['cook']);
 #### It pulls hooks from another Kareem object
 
 ```javascript
-var k1 = new Kareem();
-var test1 = function() {};
+const k1 = new Kareem();
+const test1 = function() {};
 k1.pre('cook', test1);
 k1.post('cook', function() {});
 
-var k2 = new Kareem();
-var test2 = function() {};
+const k2 = new Kareem();
+const test2 = function() {};
 k2.pre('cook', test2);
-var k3 = k2.merge(k1);
+const k3 = k2.merge(k1);
 assert.equal(k3._pres.get('cook').length, 2);
 assert.equal(k3._pres.get('cook')[0].fn, test2);
 assert.equal(k3._pres.get('cook')[1].fn, test1);
 assert.equal(k3._posts.get('cook').length, 1);
 ```
+

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ object, rather than relying on inheritance. Furthermore, kareem exposes
 an `execPre()` function that allows you to execute your pre hooks when
 appropriate, giving you more fine-grained control over your function hooks.
 
-
 #### It runs without any hooks specified
 
 ```javascript
@@ -35,7 +34,6 @@ hooks.execPre('cook', null, function() {
 
 pre hook functions take one parameter, a "done" function that you execute
 when your pre hook is finished.
-
 
 ```javascript
 let count = 0;
@@ -77,7 +75,6 @@ hooks.execPre('cook', null, function() {
 If your pre hook function takes no parameters, its assumed to be
 fully synchronous.
 
-
 ```javascript
 let count1 = 0;
 let count2 = 0;
@@ -100,7 +97,6 @@ hooks.execPre('cook', null, function(error) {
 #### It properly attaches context to pre hooks
 
 Pre save hook functions are bound to the second parameter to `execPre()`
-
 
 ```javascript
 hooks.pre('cook', function(done) {
@@ -129,7 +125,6 @@ Like the hooks module, you can declare "async" pre hooks - these take two
 parameters, the functions `next()` and `done()`. `next()` passes control to
 the next pre hook, but the underlying function won't be called until all
 async pre hooks have called `done()`.
-
 
 ```javascript
 hooks.pre('cook', true, function(next, done) {
@@ -168,7 +163,6 @@ hooks.execPre('cook', obj, function() {
 You can also return a promise from your pre hooks instead of calling
 `next()`. When the returned promise resolves, kareem will kick off the
 next middleware.
-
 
 ```javascript
 hooks.pre('cook', function() {
@@ -250,7 +244,6 @@ hooks.execPost('cook', null, [1, 2], function(error, eggs, bacon) {
 You can also return a promise from your post hooks instead of calling
 `next()`. When the returned promise resolves, kareem will kick off the
 next middleware.
-
 
 ```javascript
 hooks.post('cook', function() {
@@ -419,4 +412,3 @@ assert.equal(k3._pres.get('cook')[0].fn, test2);
 assert.equal(k3._pres.get('cook')[1].fn, test1);
 assert.equal(k3._posts.get('cook').length, 1);
 ```
-

--- a/README.md
+++ b/README.md
@@ -183,8 +183,6 @@ hooks.execPre('cook', obj, function() {
 
 ## post hooks
 
-acquit:ignore:end
-
 ### It runs without any hooks specified
 
 ```javascript
@@ -263,8 +261,6 @@ hooks.execPost('cook', obj, obj, function() {
 ```
 
 ## wrap()
-
-acquit:ignore:end
 
 ### It wraps pre and post calls into one call
 
@@ -378,8 +374,6 @@ cook(obj, function(error, result) {
 ```
 
 ## clone()
-
-acquit:ignore:end
 
 ### It clones a Kareem object
 

--- a/docs.js
+++ b/docs.js
@@ -19,15 +19,13 @@ if (untilIndex <= 0) {
 
 let mdOutput = existingReadme.substring(0, untilIndex + searchRegion.length) + '\n\n# API\n\n';
 
-for (let i = 0; i < blocks.length; ++i) {
-  const describe = blocks[i];
+for (const describe of blocks) {
   mdOutput += '## ' + describe.contents + '\n\n';
   mdOutput += describe.comments[0] ?
     acquit.trimEachLine(describe.comments[0]) + '\n\n' :
     '';
 
-  for (let j = 0; j < describe.blocks.length; ++j) {
-    const it = describe.blocks[j];
+  for (const it of describe.blocks) {
     mdOutput += '#### It ' + it.contents + '\n\n';
     mdOutput += it.comments[0] ?
       acquit.trimEachLine(it.comments[0]) + '\n\n' :

--- a/docs.js
+++ b/docs.js
@@ -31,7 +31,7 @@ for (const describe of blocks) {
 
   for (const it of describe.blocks) {
     mdOutput += '\n\n';
-    mdOutput += '#### It ' + it.contents + '\n\n';
+    mdOutput += '### It ' + it.contents + '\n\n';
 
     if (it.comments[0]) {
       mdOutput += acquit.trimEachLine(it.comments[0]) + '\n';

--- a/docs.js
+++ b/docs.js
@@ -17,23 +17,32 @@ if (untilIndex <= 0) {
   throw new Error('Region ' + JSON.stringify(searchRegion) + ' not found!');
 }
 
-let mdOutput = existingReadme.substring(0, untilIndex + searchRegion.length) + '\n\n# API\n\n';
+let mdOutput = existingReadme.substring(0, untilIndex + searchRegion.length) + '\n\n# API';
 
 for (const describe of blocks) {
-  mdOutput += '## ' + describe.contents + '\n\n';
-  mdOutput += describe.comments[0] ?
-    acquit.trimEachLine(describe.comments[0]) + '\n\n' :
-    '';
+  mdOutput += '\n\n';
+  mdOutput += '## ' + describe.contents;
+  // only add spacing and comments, if there are comments
+  if (describe.comments[0]) {
+    mdOutput += '\n\n';
+    // acquit "trimEachLine" does not actually trim the last line for some reason
+    mdOutput += acquit.trimEachLine(describe.comments[0]).trim();
+  }
 
   for (const it of describe.blocks) {
+    mdOutput += '\n\n';
     mdOutput += '#### It ' + it.contents + '\n\n';
-    mdOutput += it.comments[0] ?
-      acquit.trimEachLine(it.comments[0]) + '\n\n' :
-      '';
+
+    if (it.comments[0]) {
+      mdOutput += acquit.trimEachLine(it.comments[0]) + '\n';
+    }
+
     mdOutput += '```javascript\n';
     mdOutput += it.code + '\n';
-    mdOutput += '```\n\n';
+    mdOutput += '```';
   }
 }
+
+mdOutput += '\n';
 
 fs.writeFileSync('README.md', mdOutput);

--- a/docs.js
+++ b/docs.js
@@ -1,23 +1,23 @@
 'use strict';
 
 const acquit = require('acquit');
+const fs = require('fs');
 
 require('acquit-ignore')();
 
-const content = require('fs').readFileSync('./test/examples.test.js').toString();
+const content = fs.readFileSync('./test/examples.test.js').toString();
 const blocks = acquit.parse(content);
 
-let mdOutput =
-  '# kareem\n\n' +
-  '  [![Build Status](https://github.com/mongoosejs/kareem/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/mongoosejs/kareem/actions/workflows/test.yml)\n' +
-  '  <!--[![Coverage Status](https://img.shields.io/coveralls/vkarpov15/kareem.svg)](https://coveralls.io/r/vkarpov15/kareem)-->\n\n' +
-  'Re-imagined take on the [hooks](http://npmjs.org/package/hooks) module, ' +
-  'meant to offer additional flexibility in allowing you to execute hooks ' +
-  'whenever necessary, as opposed to simply wrapping a single function.\n\n' +
-  'Named for the NBA\'s all-time leading scorer Kareem Abdul-Jabbar, known ' +
-  'for his mastery of the [hook shot](http://en.wikipedia.org/wiki/Kareem_Abdul-Jabbar#Skyhook)\n\n' +
-  '<img src="http://upload.wikimedia.org/wikipedia/commons/0/00/Kareem-Abdul-Jabbar_Lipofsky.jpg" width="220">\n\n' +
-  '# API\n\n';
+// include the README until after the specified tag as static non-generated content
+const existingReadme = fs.readFileSync('./README.md').toString();
+const searchRegion = '<!--DOCS START-->';
+const untilIndex = existingReadme.indexOf(searchRegion);
+
+if (untilIndex <= 0) {
+  throw new Error('Region ' + JSON.stringify(searchRegion) + ' not found!');
+}
+
+let mdOutput = existingReadme.substring(0, untilIndex + searchRegion.length) + '\n\n# API\n\n';
 
 for (let i = 0; i < blocks.length; ++i) {
   const describe = blocks[i];
@@ -38,4 +38,4 @@ for (let i = 0; i < blocks.length; ++i) {
   }
 }
 
-require('fs').writeFileSync('README.md', mdOutput);
+fs.writeFileSync('README.md', mdOutput);

--- a/docs.js
+++ b/docs.js
@@ -13,8 +13,7 @@ const existingReadme = fs.readFileSync('./README.md').toString();
 const searchRegion = '<!--DOCS START-->';
 const untilIndex = existingReadme.indexOf(searchRegion);
 
-if (untilIndex <= 0) {
-  throw new Error('Region ' + JSON.stringify(searchRegion) + ' not found!');
+if (untilIndex === -1) {
 }
 
 let mdOutput = existingReadme.substring(0, untilIndex + searchRegion.length) + '\n\n# API';

--- a/docs.js
+++ b/docs.js
@@ -9,8 +9,8 @@ const blocks = acquit.parse(content);
 
 let mdOutput =
   '# kareem\n\n' +
-  '  [![Build Status](https://travis-ci.org/vkarpov15/kareem.svg?branch=master)](https://travis-ci.org/vkarpov15/kareem)\n' +
-  '  [![Coverage Status](https://img.shields.io/coveralls/vkarpov15/kareem.svg)](https://coveralls.io/r/vkarpov15/kareem)\n\n' +
+  '  [![Build Status](https://github.com/mongoosejs/kareem/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/mongoosejs/kareem/actions/workflows/test.yml)\n' +
+  '  <!--[![Coverage Status](https://img.shields.io/coveralls/vkarpov15/kareem.svg)](https://coveralls.io/r/vkarpov15/kareem)-->\n\n' +
   'Re-imagined take on the [hooks](http://npmjs.org/package/hooks) module, ' +
   'meant to offer additional flexibility in allowing you to execute hooks ' +
   'whenever necessary, as opposed to simply wrapping a single function.\n\n' +

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -4,6 +4,8 @@ const assert = require('assert');
 const { beforeEach, describe, it } = require('mocha');
 const Kareem = require('../');
 
+// NOTE: this file has some empty comment lines to workaround https://github.com/vkarpov15/acquit/issues/30
+
 /* Much like [hooks](https://npmjs.org/package/hooks), kareem lets you define
  * pre and post hooks: pre hooks are called before a given function executes.
  * Unlike hooks, kareem stores hooks and other internal state in a separate
@@ -185,6 +187,7 @@ describe('pre hooks', function() {
   });
 });
 
+//
 describe('post hooks', function() {
   let hooks;
 
@@ -271,6 +274,7 @@ describe('post hooks', function() {
   });
 });
 
+//
 describe('wrap()', function() {
   let hooks;
 
@@ -336,6 +340,7 @@ describe('wrap()', function() {
   });
 });
 
+//
 describe('createWrapper()', function() {
   let hooks;
 
@@ -398,6 +403,7 @@ describe('createWrapper()', function() {
   });
 });
 
+//
 describe('clone()', function() {
   it('clones a Kareem object', function() {
     const k1 = new Kareem();
@@ -410,6 +416,7 @@ describe('clone()', function() {
   });
 });
 
+//
 describe('merge()', function() {
   it('pulls hooks from another Kareem object', function() {
     const k1 = new Kareem();


### PR DESCRIPTION
This PR updates the README documentation as it had not been done in a while and update the script to be better useable. In more details:
- re-run the docs script to update code to latest version
- change script to include existing README content until a specific tag
- change script to have less extraneous spacing
- reduce header count by 1 (h4 -> h3)
- workaround the random `acquit:ignore:end` text https://github.com/vkarpov15/acquit/issues/30